### PR TITLE
Tighten filebeat permissions

### DIFF
--- a/tasks/flavor-specific/filebeat.yml
+++ b/tasks/flavor-specific/filebeat.yml
@@ -25,7 +25,7 @@
           {{ beats_filebeat_inputs_dir }}/{{
             _beats__input_file | basename | regex_replace('^(.*)[.]j2', '\\1')
           }}
-        mode: 0o644
+        mode: 0o600
       loop: "{{ beats_filebeat_input_files }}"
       loop_control:
         loop_var: _beats__input_file


### PR DESCRIPTION
The list of inputs can be considered sensitive in some environments. Setting the file mode to owner-only is sufficient for the beat to function.